### PR TITLE
fix: Change method name as it conflicts with Laravel method

### DIFF
--- a/src/Mixins/ArrMixin.php
+++ b/src/Mixins/ArrMixin.php
@@ -46,7 +46,7 @@ class ArrMixin
 	 * 		'leases.*.roommates.*.tenant.userClient'
 	 * ]
 	 */
-	public function select(): callable
+	public function selectWildcard(): callable
 	{
 		return static function ($array, array $keys, bool $keysAlreadyParsed = false) {
 			$result = [];
@@ -69,7 +69,7 @@ class ArrMixin
 				// If the key has a wildcard after and
 				// our dataset value is iterable - map.
 				if ($group !== null && $group !== [null] && is_iterable($value)) {
-					$mapper = static fn ($item) => Arr::select($item, $group);
+					$mapper = static fn ($item) => Arr::selectWildcard($item, $group);
 
 					// array_map doesn't work with Collections and
 					// I don't want to leave type of iterable the same.

--- a/tests/ArrMixin/ArrSelectTest.php
+++ b/tests/ArrMixin/ArrSelectTest.php
@@ -212,6 +212,6 @@ class ArrSelectTest extends TestCase
 
 	protected function assertSelectedTestingValue(array $expected, array $keys): void
 	{
-		$this->assertEquals($expected, Arr::select(self::TESTING_VALUE, $keys));
+		$this->assertEquals($expected, Arr::selectWildcard(self::TESTING_VALUE, $keys));
 	}
 }


### PR DESCRIPTION
BREAKING CHANGE: Renamed Arr::select() to Arr::selectWildcard()